### PR TITLE
Refactor/blob-analyzer

### DIFF
--- a/extension/scripts/url monitor/blob-analyzer.js
+++ b/extension/scripts/url monitor/blob-analyzer.js
@@ -1,5 +1,5 @@
 /**
- * audio-analyzer.js
+ * blob-analyzer.js
  * 負責處理音檔分析相關功能，包含持續時間計算和音訊資料處理
  */
 
@@ -11,7 +11,7 @@ import {
 } from "../utils/constants.js";
 
 // 創建模組特定的日誌記錄器
-const logger = Logger.createModuleLogger(MODULE_NAMES.AUDIO_ANALYZER);
+const logger = Logger.createModuleLogger(MODULE_NAMES.BLOB_ANALYZER);
 
 /**
  * 從 Blob 中計算音訊持續時間
@@ -21,7 +21,7 @@ const logger = Logger.createModuleLogger(MODULE_NAMES.AUDIO_ANALYZER);
  * @param {string} [blobType] - blob 類型 (如果傳入 URL，則此參數為必須)
  * @returns {Promise<number>} - 返回音訊持續時間（毫秒）的 Promise
  */
-export async function calculateAudioDuration(blobOrUrl, blobType = null) {
+export async function calculateBlobDuration(blobOrUrl, blobType = null) {
   try {
     logger.debug("開始計算音訊持續時間");
 
@@ -331,7 +331,7 @@ export function isLikelyVoiceMessageBlob(blob) {
 
 // 匯出所有功能
 export default {
-  calculateAudioDuration,
+  calculateBlobDuration,
   extractBlobContent,
   isLikelyVoiceMessageBlob,
 };

--- a/extension/scripts/url monitor/blob-monitor.js
+++ b/extension/scripts/url monitor/blob-monitor.js
@@ -10,10 +10,10 @@ import {
   BLOB_MONITOR_CONSTANTS,
 } from "../utils/constants.js";
 import {
-  calculateAudioDuration,
+  calculateBlobDuration,
   isLikelyVoiceMessageBlob,
   extractBlobContent,
-} from "../audio/audio-analyzer.js";
+} from "./blob-analyzer.js";
 
 // 創建模組特定的日誌記錄器
 const logger = Logger.createModuleLogger(MODULE_NAMES.BLOB_MONITOR);
@@ -71,7 +71,7 @@ const BlobProcessingQueue = {
       this.processedBlobs.set(blob, true);
 
       // 計算音訊持續時間
-      const durationMs = await calculateAudioDuration(blob);
+      const durationMs = await calculateBlobDuration(blob);
 
       // 註冊到背景腳本
       registerBlobWithBackend(blob, blobUrl, durationMs);

--- a/extension/scripts/utils/constants.js
+++ b/extension/scripts/utils/constants.js
@@ -208,7 +208,7 @@ export const MODULE_NAMES = {
   WEB_REQUEST: "web-request-interceptor",
   DOM_DETECTOR: "dom-detector",
   CONTEXT_MENU: "context-menu-handler",
-  AUDIO_ANALYZER: "audio-analyzer",
+  BLOB_ANALYZER: "blob-analyzer",
   BLOB_MONITOR: "blob-monitor",
 };
 


### PR DESCRIPTION
- 改名 blob-analyzer.js 檔案，實現音訊 Blob 的持續時間計算、內容提取及音訊檔案評估功能，提升擴充功能的音訊處理能力。
- 將音訊持續時間計算邏輯從 audio-analyzer.js 移至 blob-analyzer.js，並更新 blob-monitor.js 中的引用，確保代碼結構更清晰。
- 此變更有助於統一管理音訊分析邏輯，並為未來的功能擴展提供基礎。