### PR TITLE
refactor(content-message-handler): 新增內容腳本訊息處理器

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -13,6 +13,7 @@ import {
   MODULE_NAMES,
 } from "./utils/constants.js";
 import { handleExtractBlobRequest } from "./url monitor/blob-monitor.js";
+import { initMessageHandler } from "./content/message-handler.js";
 
 // 創建模組特定的日誌記錄器
 const logger = Logger.createModuleLogger(MODULE_NAMES.CONTENT_SCRIPT);
@@ -71,6 +72,13 @@ if (!isSupportedSite) {
     );
     return true;
   });
+
+  // 初始化內容腳本訊息處理器
+  // 確保主模組和 sendToBackground 函數已經載入
+  setTimeout(() => {
+    initMessageHandler();
+    logger.debug("內容腳本訊息處理器已初始化");
+  }, 300);
 
   logger.info("Facebook Messenger 語音訊息下載器已初始化");
 }

--- a/extension/scripts/content/message-handler.js
+++ b/extension/scripts/content/message-handler.js
@@ -1,0 +1,99 @@
+/**
+ * message-handler.js
+ * 負責處理來自背景腳本的訊息並路由到正確的處理器
+ */
+
+import { Logger } from "../utils/logger.js";
+import {
+  MESSAGE_SOURCES,
+  MESSAGE_ACTIONS,
+  MODULE_NAMES,
+} from "../utils/constants.js";
+import { handleGetAudioDurationRequest } from "../url monitor/audio-analyzer.js";
+
+// 創建模組特定的日誌記錄器
+const logger = Logger.createModuleLogger(MODULE_NAMES.CONTENT_MESSAGE_HANDLER);
+
+/**
+ * 初始化訊息處理器
+ * 設置訊息監聽器，處理來自背景腳本的訊息
+ */
+export function initMessageHandler() {
+  logger.debug("初始化內容腳本訊息處理器");
+
+  // 設置訊息監聽器，處理與內容腳本的通訊
+  window.addEventListener("message", async function (event) {
+    // 確保訊息來自同一個頁面
+    if (event.source !== window) return;
+
+    // 處理來自內容腳本的訊息
+    if (
+      event.data.type &&
+      event.data.type === MESSAGE_SOURCES.BACKGROUND_SCRIPT
+    ) {
+      const message = event.data.message;
+      logger.debug("收到背景腳本訊息", { message });
+
+      // 根據訊息動作路由到對應的處理器
+      handleMessage(message);
+    }
+  });
+
+  logger.info("內容腳本訊息處理器已初始化");
+}
+
+/**
+ * 根據訊息類型路由到對應的處理器
+ * @param {Object} message - 接收到的訊息
+ */
+async function handleMessage(message) {
+  logger.debug("開始處理訊息", { action: message.action });
+
+  switch (message.action) {
+    case MESSAGE_ACTIONS.GET_AUDIO_DURATION:
+      logger.debug("處理獲取音訊時長請求");
+      const durationMs = await handleGetAudioDurationRequest(message);
+
+      // 只有在成功獲得持續時間後才註冊
+      if (durationMs !== undefined && durationMs !== null) {
+        registerAudioUrlWithBackend(message.url, durationMs);
+      } else {
+        logger.debug("獲取的音訊持續時間無效", { url: message.url });
+      }
+      break;
+
+    // 可以添加更多訊息類型的處理...
+
+    default:
+      logger.warn("未處理的訊息類型", {
+        action: message.action || "無動作",
+      });
+      break;
+  }
+}
+
+/**
+ * 向背景腳本註冊 Audio URL
+ * @param {string} url - 音訊 URL
+ * @param {number} durationMs - 音訊持續時間（毫秒）
+ */
+function registerAudioUrlWithBackend(url, durationMs) {
+  // 建立要發送的訊息
+  const message = {
+    action: MESSAGE_ACTIONS.REGISTER_AUDIO_URL,
+    audioUrl: url,
+    durationMs: durationMs,
+    timestamp: new Date().toISOString(),
+  };
+
+  // 使用 chrome.runtime.sendMessage 直接發送給背景腳本
+  chrome.runtime.sendMessage(message, function (response) {
+    logger.debug("註冊 Audio URL 回應", { response });
+  });
+
+  // 記錄詳細資訊
+  logger.debug("向背景腳本發送 Audio URL 註冊資訊", {
+    audioUrl: url.substring(0, 50),
+    durationMs: durationMs,
+  });
+}

--- a/extension/scripts/main-module.js
+++ b/extension/scripts/main-module.js
@@ -12,7 +12,6 @@ import {
   MESSAGE_ACTIONS,
 } from "./utils/constants.js";
 import { initBlobMonitor } from "./url monitor/blob-monitor.js";
-import { handleGetAudioDurationRequest } from "./url monitor/audio-analyzer.js";
 
 // 創建模組特定的日誌記錄器
 const logger = Logger.createModuleLogger(MODULE_NAMES.MAIN_MODULE);
@@ -36,7 +35,7 @@ function initialize() {
   // 初始化 Blob 監控模組
   initBlobMonitor();
 
-  // 初始化右鍵選單處理器 - 不再傳遞 voiceMessages 參數
+  // 初始化右鍵選單處理器
   initContextMenuHandler();
 
   logger.debug("使用 webRequest API 模式，不再使用 fetch 代理攝截");
@@ -55,34 +54,7 @@ function initialize() {
     "*"
   );
 
-  // 設置訊息監聽器，處理與內容腳本的通訊
-  window.addEventListener("message", async function (event) {
-    // 確保訊息來自同一個頁面
-    if (event.source !== window) return;
-
-    // 處理來自內容腳本的訊息
-    if (
-      event.data.type &&
-      event.data.type === MESSAGE_SOURCES.BACKGROUND_SCRIPT
-    ) {
-      // 處理來自背景腳本的訊息
-      const message = event.data.message;
-
-      // 根據訊息類型處理
-      if (message.action === MESSAGE_ACTIONS.GET_AUDIO_DURATION) {
-        const durationMs = await handleGetAudioDurationRequest(message);
-
-        // 只有在成功獲得持續時間後才註冊
-        if (durationMs !== undefined && durationMs !== null) {
-          registerAudioUrlWithBackend(message.url, durationMs);
-        } else {
-          logger.debug("獲取的音訊持續時間無效", { url: message.url });
-        }
-      }
-    }
-  });
-
-  // 向內容腳本發送訊息的輔助函數
+  // 定義向背景腳本發送訊息的輔助函數
   window.sendToBackground = function (message) {
     try {
       logger.debug("準備發送訊息到背景腳本", { message });
@@ -112,23 +84,4 @@ if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", initialize);
 } else {
   initialize();
-}
-
-/**
- * 向背景腳本註冊 Audio URL
- */
-function registerAudioUrlWithBackend(url, durationMs) {
-  // 發送註冊訊息到背景腳本
-  window.sendToBackground({
-    action: MESSAGE_ACTIONS.REGISTER_AUDIO_URL,
-    audioUrl: url,
-    durationMs: durationMs,
-    timestamp: new Date().toISOString(),
-  });
-
-  // 記錄詳細資訊
-  logger.debug("向背景腳本發送 Audio URL 註冊資訊", {
-    audioUrl: url.substring(0, 50),
-    durationMs: durationMs,
-  });
 }

--- a/extension/scripts/utils/constants.js
+++ b/extension/scripts/utils/constants.js
@@ -231,6 +231,7 @@ export const MODULE_NAMES = {
   MAIN_MODULE: "main-module",
   MENU_MANAGER: "menu-manager",
   MESSAGE_HANDLER: "message-handler",
+  CONTENT_MESSAGE_HANDLER: "content-message-handler",
   DOWNLOAD_MANAGER: "download-manager",
   DATA_STORE: "data-store",
   WEB_REQUEST: "web-request-interceptor",


### PR DESCRIPTION
- 在 content/message-handler.js 中實作訊息處理器，負責處理來自背景腳本的訊息並路由到正確的處理器，提升模組化與可維護性。
- 在 content.js 中初始化訊息處理器，確保主模組與 sendToBackground 函數已載入，增強訊息通訊的穩定性。
- 移除 main-module.js 中不再使用的訊息監聽邏輯，簡化代碼結構，提升可讀性。
- 此變更有助於清晰分離訊息處理邏輯，為未來的功能擴展提供更好的基礎。