### PR TITLE
Feat/no-log-in-prod

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,9 @@
       "Bash(npx tsc:*)",
       "Bash(mkdir:*)",
       "Bash(pnpm lint:*)",
-      "Bash(rg:*)"
+      "Bash(rg:*)",
+      "Bash(pnpm dev:*)",
+      "Bash(pnpm webpack:*)"
     ],
     "deny": []
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -48,7 +48,6 @@
     }
   ],
   "background": {
-    "service_worker": "scripts/background.js",
-    "type": "module"
+    "service_worker": "scripts/background.js"
   }
 }

--- a/extension/scripts/utils/logger.ts
+++ b/extension/scripts/utils/logger.ts
@@ -7,10 +7,16 @@ import type { LoggerConfig, ModuleLogger } from "../types/utils";
 
 import { LOG_LEVELS, type LogLevel, type ModuleName } from "./constants";
 
+// 宣告建置時注入的環境變數
+declare const __IS_PRODUCTION__: boolean;
+
+// 根據環境設定預設日誌級別
+const defaultLogLevel = __IS_PRODUCTION__ ? LOG_LEVELS.WARN : LOG_LEVELS.DEBUG;
+
 // 預設配置
 let config: LoggerConfig = {
-  // 當前日誌級別，可透過設置調整
-  level: LOG_LEVELS.DEBUG,
+  // 當前日誌級別，根據環境自動調整
+  level: defaultLogLevel,
 
   // 是否顯示時間戳
   showTimestamp: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,13 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 
-module.exports = {
-  mode: "development", // 開發模式，可以改為 'production' 用於生產環境
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === 'production';
+  
+  return {
+    mode: argv.mode || "development",
+    devtool: false, // 禁用 eval，避免 CSP 問題
 
   entry: {
     // 背景腳本
@@ -43,6 +48,9 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.DefinePlugin({
+      '__IS_PRODUCTION__': JSON.stringify(isProduction)
+    }),
     new CopyPlugin({
       patterns: [
         {
@@ -70,4 +78,5 @@ module.exports = {
   resolve: {
     extensions: [".js", ".ts"], // 自動解析的擴展名
   },
+  };
 };


### PR DESCRIPTION
- Updated webpack.config.js to support dynamic mode configuration and added a DefinePlugin for environment variable injection.
- Modified logger.ts to adjust the default log level based on the production environment, enhancing logging behavior.
- Cleaned up the manifest.json by removing the 'type' field from the background configuration.