### PR TITLE
Feat/download-all-audio-when-not-match-aria-label

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,8 @@
       "Bash(tree:*)",
       "Bash(git checkout:*)",
       "Bash(pnpm typecheck:*)",
-      "Bash(pnpm quality:*)"
+      "Bash(pnpm quality:*)",
+      "Bash(pnpm run lint:*)"
     ],
     "deny": []
   }

--- a/extension/scripts/background.ts
+++ b/extension/scripts/background.ts
@@ -54,7 +54,7 @@ function initialize(): VoiceMessageStore {
     logger.debug("Context menu manager initialized");
 
     // Initialize download manager
-    initDownloadManager();
+    initDownloadManager(voiceMessages);
     logger.debug("Download manager initialized");
 
     // Initialize message handler

--- a/extension/scripts/background/download-manager.ts
+++ b/extension/scripts/background/download-manager.ts
@@ -76,8 +76,9 @@ export function setLastRightClickedInfo(info: RightClickInfo): void {
  *
  * @param url - Download URL
  * @param lastModified - Last-Modified header value
+ * @param uniqueIdentifier - Unique identifier to avoid filename conflicts (e.g., voice message ID or duration)
  */
-export function downloadVoiceMessage(url: string, lastModified?: string): void {
+export function downloadVoiceMessage(url: string, lastModified?: string, uniqueIdentifier?: string): void {
   logger.debug("downloadVoiceMessage function called");
 
   if (!url) {
@@ -85,9 +86,13 @@ export function downloadVoiceMessage(url: string, lastModified?: string): void {
     return;
   }
 
-  // Generate filename
-  const filename = `${generateVoiceMessageFilename(lastModified)}.mp4`;
-  logger.debug("Generated filename", { filename });
+  // Generate filename with unique identifier
+  const baseFilename = generateVoiceMessageFilename(lastModified);
+  const filename = uniqueIdentifier 
+    ? `${baseFilename}-${uniqueIdentifier}.mp4`
+    : `${baseFilename}.mp4`;
+  
+  logger.debug("Generated filename", { filename, uniqueIdentifier });
 
   // Use Chrome downloads API to download the file
   logger.debug("Preparing to call chrome.downloads.download API");
@@ -140,7 +145,8 @@ export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore):
         url: item.downloadUrl.substring(0, 50) + "...",
       });
 
-      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined);
+      // Use voice message ID as unique identifier to prevent filename conflicts
+      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined, id);
       downloadCount++;
     } else {
       logger.debug("Skipping item without valid download URL", {

--- a/extension/scripts/background/download-manager.ts
+++ b/extension/scripts/background/download-manager.ts
@@ -46,11 +46,11 @@ export function initDownloadManager(voiceMessagesStore?: VoiceMessageStore): voi
               lastRightClickedInfo.lastModified || undefined
             );
           } else {
-            logger.info("No specific voice message URL found, triggering batch download with saveAs: false");
+            logger.info("No specific voice message URL found, triggering batch download with first dialog");
             // Directly call downloadAllVoiceMessages if voiceMessagesStore is available
             if (voiceMessagesStore) {
-              const downloadCount = downloadAllVoiceMessages(voiceMessagesStore);
-              logger.info("Batch download triggered", { downloadCount });
+              const downloadCount = downloadAllVoiceMessages(voiceMessagesStore, true);
+              logger.info("Batch download triggered with first dialog", { downloadCount });
             } else {
               logger.error("Cannot trigger batch download: voiceMessagesStore not available");
             }
@@ -133,9 +133,10 @@ export function downloadVoiceMessage(url: string, lastModified?: string, uniqueI
  * Download all voice messages from the data store
  *
  * @param voiceMessagesStore - Voice message data store
+ * @param showFirstDialog - Whether to show save dialog for the first file (defaults to false)
  * @returns Number of downloads started
  */
-export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore): number {
+export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore, showFirstDialog: boolean = false): number {
   logger.debug("downloadAllVoiceMessages function called");
 
   if (!voiceMessagesStore || !voiceMessagesStore.items) {
@@ -144,23 +145,30 @@ export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore):
   }
 
   let downloadCount = 0;
+  let isFirstFile = true;
 
   logger.debug("Iterating through voice message store", {
     totalItems: voiceMessagesStore.items.size,
+    showFirstDialog,
   });
 
   for (const [id, item] of voiceMessagesStore.items.entries()) {
     if (item.downloadUrl && item.downloadUrl.trim() !== "") {
+      // Determine saveAs value: first file uses showFirstDialog, others use false
+      const useSaveAs = isFirstFile && showFirstDialog;
+      
       logger.debug("Downloading voice message", {
         id,
         durationMs: item.durationMs,
         url: item.downloadUrl.substring(0, 50) + "...",
+        isFirstFile,
+        useSaveAs,
       });
 
       // Use voice message ID as unique identifier to prevent filename conflicts
-      // Use saveAs: false for batch downloads to avoid multiple save dialogs
-      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined, id, false);
+      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined, id, useSaveAs);
       downloadCount++;
+      isFirstFile = false; // Mark that we've processed the first file
     } else {
       logger.debug("Skipping item without valid download URL", {
         id,

--- a/extension/scripts/background/download-manager.ts
+++ b/extension/scripts/background/download-manager.ts
@@ -19,7 +19,7 @@ let lastRightClickedInfo: RightClickInfo | null = null;
 /**
  * Initialize the download manager
  */
-export function initDownloadManager(): void {
+export function initDownloadManager(voiceMessagesStore?: VoiceMessageStore): void {
   logger.info("Initializing download manager");
 
   // Listen for context menu click events
@@ -35,16 +35,26 @@ export function initDownloadManager(): void {
 
       if (info.menuItemId === "downloadVoiceMessage") {
         if (lastRightClickedInfo) {
-          logger.info("Starting voice message download", {
-            url: lastRightClickedInfo.downloadUrl
-              ? lastRightClickedInfo.downloadUrl.substring(0, 50) + "..."
-              : null,
-            lastModified: lastRightClickedInfo.lastModified,
-          });
-          downloadVoiceMessage(
-            lastRightClickedInfo.downloadUrl!,
-            lastRightClickedInfo.lastModified || undefined
-          );
+          // Check if downloadUrl is valid
+          if (lastRightClickedInfo.downloadUrl) {
+            logger.info("Starting individual voice message download", {
+              url: lastRightClickedInfo.downloadUrl.substring(0, 50) + "...",
+              lastModified: lastRightClickedInfo.lastModified,
+            });
+            downloadVoiceMessage(
+              lastRightClickedInfo.downloadUrl,
+              lastRightClickedInfo.lastModified || undefined
+            );
+          } else {
+            logger.info("No specific voice message URL found, triggering batch download with saveAs: false");
+            // Directly call downloadAllVoiceMessages if voiceMessagesStore is available
+            if (voiceMessagesStore) {
+              const downloadCount = downloadAllVoiceMessages(voiceMessagesStore);
+              logger.info("Batch download triggered", { downloadCount });
+            } else {
+              logger.error("Cannot trigger batch download: voiceMessagesStore not available");
+            }
+          }
         } else {
           logger.error("Cannot download, no right-click info available");
         }

--- a/extension/scripts/background/download-manager.ts
+++ b/extension/scripts/background/download-manager.ts
@@ -77,8 +77,9 @@ export function setLastRightClickedInfo(info: RightClickInfo): void {
  * @param url - Download URL
  * @param lastModified - Last-Modified header value
  * @param uniqueIdentifier - Unique identifier to avoid filename conflicts (e.g., voice message ID or duration)
+ * @param saveAs - Whether to show save dialog (defaults to DOWNLOAD_CONSTANTS.SAVE_AS)
  */
-export function downloadVoiceMessage(url: string, lastModified?: string, uniqueIdentifier?: string): void {
+export function downloadVoiceMessage(url: string, lastModified?: string, uniqueIdentifier?: string, saveAs?: boolean): void {
   logger.debug("downloadVoiceMessage function called");
 
   if (!url) {
@@ -95,12 +96,13 @@ export function downloadVoiceMessage(url: string, lastModified?: string, uniqueI
   logger.debug("Generated filename", { filename, uniqueIdentifier });
 
   // Use Chrome downloads API to download the file
-  logger.debug("Preparing to call chrome.downloads.download API");
+  const useSaveAs = saveAs !== undefined ? saveAs : DOWNLOAD_CONSTANTS.SAVE_AS;
+  logger.debug("Preparing to call chrome.downloads.download API", { saveAs: useSaveAs });
   chrome.downloads.download(
     {
       url: url,
       filename: filename,
-      saveAs: DOWNLOAD_CONSTANTS.SAVE_AS,
+      saveAs: useSaveAs,
     },
     (downloadId) => {
       if (chrome.runtime.lastError) {
@@ -146,7 +148,8 @@ export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore):
       });
 
       // Use voice message ID as unique identifier to prevent filename conflicts
-      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined, id);
+      // Use saveAs: false for batch downloads to avoid multiple save dialogs
+      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined, id, false);
       downloadCount++;
     } else {
       logger.debug("Skipping item without valid download URL", {

--- a/extension/scripts/background/download-manager.ts
+++ b/extension/scripts/background/download-manager.ts
@@ -8,6 +8,8 @@ import { Logger } from "../utils/logger";
 import { DOWNLOAD_CONSTANTS } from "../utils/constants";
 import type { RightClickInfo } from "../types/download";
 
+import type { VoiceMessageStore } from "./data-store";
+
 // Create a module-specific logger
 const logger = Logger.createModuleLogger("download-manager");
 
@@ -108,4 +110,51 @@ export function downloadVoiceMessage(url: string, lastModified?: string): void {
     url: url.substring(0, 50) + "...",
     filename,
   });
+}
+
+/**
+ * Download all voice messages from the data store
+ *
+ * @param voiceMessagesStore - Voice message data store
+ * @returns Number of downloads started
+ */
+export function downloadAllVoiceMessages(voiceMessagesStore: VoiceMessageStore): number {
+  logger.debug("downloadAllVoiceMessages function called");
+
+  if (!voiceMessagesStore || !voiceMessagesStore.items) {
+    logger.error("Invalid voice messages store");
+    return 0;
+  }
+
+  let downloadCount = 0;
+
+  logger.debug("Iterating through voice message store", {
+    totalItems: voiceMessagesStore.items.size,
+  });
+
+  for (const [id, item] of voiceMessagesStore.items.entries()) {
+    if (item.downloadUrl && item.downloadUrl.trim() !== "") {
+      logger.debug("Downloading voice message", {
+        id,
+        durationMs: item.durationMs,
+        url: item.downloadUrl.substring(0, 50) + "...",
+      });
+
+      downloadVoiceMessage(item.downloadUrl, item.lastModified || undefined);
+      downloadCount++;
+    } else {
+      logger.debug("Skipping item without valid download URL", {
+        id,
+        hasUrl: !!item.downloadUrl,
+        urlLength: item.downloadUrl?.length || 0,
+      });
+    }
+  }
+
+  logger.info("Batch download completed", {
+    downloadCount,
+    totalItems: voiceMessagesStore.items.size,
+  });
+
+  return downloadCount;
 }

--- a/extension/scripts/background/handlers/download-all-handler.ts
+++ b/extension/scripts/background/handlers/download-all-handler.ts
@@ -1,0 +1,67 @@
+/**
+ * download-all-handler.ts
+ * Handles download all voice messages related messages
+ */
+
+import { downloadAllVoiceMessages } from "../download-manager";
+import { Logger } from "../../utils/logger";
+import { type VoiceMessageStore } from "../data-store";
+import type { DownloadAllMessage } from "../../types/messages";
+
+// Create a module-specific logger
+const logger = Logger.createModuleLogger("download-all-handler");
+
+/**
+ * Handle download all voice messages message
+ *
+ * @param voiceMessagesStore - Voice message data store
+ * @param message - Message object
+ * @param sender - Sender info
+ * @param sendResponse - Response callback
+ * @returns Whether to keep the connection open
+ */
+export function handleDownloadAll(
+  voiceMessagesStore: VoiceMessageStore,
+  message: DownloadAllMessage,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: any) => void
+): boolean {
+  logger.debug("Handling download all voice messages request");
+
+  // Ensure we have voiceMessagesStore
+  if (!voiceMessagesStore) {
+    logger.error("voiceMessagesStore does not exist");
+    sendResponse({
+      success: false,
+      message: "Internal error: voiceMessagesStore does not exist",
+    });
+    return true;
+  }
+
+  logger.debug("voiceMessagesStore Map size", {
+    mapSize: voiceMessagesStore.items ? voiceMessagesStore.items.size : 0,
+  });
+
+  // Execute batch download
+  logger.info("Executing batch download of all available voice messages");
+  const downloadCount = downloadAllVoiceMessages(voiceMessagesStore);
+
+  if (downloadCount > 0) {
+    logger.info("Batch download initiated", { downloadCount });
+    sendResponse({
+      success: true,
+      message: `Started downloading all available voice messages (${downloadCount} files)`,
+      downloadCount,
+    });
+  } else {
+    logger.warn("No downloadable voice messages found in cache");
+    sendResponse({
+      success: true,
+      message: "No downloadable voice messages available in cache",
+      downloadCount: 0,
+    });
+  }
+
+  logger.debug("Download all voice messages handling complete");
+  return true; // Keep the connection open for async response
+}

--- a/extension/scripts/background/handlers/right-click-handler.ts
+++ b/extension/scripts/background/handlers/right-click-handler.ts
@@ -5,7 +5,7 @@
 
 import { setLastRightClickedInfo } from "../download-manager";
 import { Logger } from "../../utils/logger";
-import { MODULE_NAMES } from "../../utils/constants";
+import { MODULE_NAMES, MESSAGE_ACTIONS } from "../../utils/constants";
 import { type VoiceMessageStore, type VoiceMessageItem } from "../data-store";
 import type { RightClickMessage } from "../../types/messages";
 
@@ -102,9 +102,12 @@ export function handleRightClick(
       durationMs: durationMs || undefined,
     });
 
+    // Suggest downloading all available voice messages as fallback
+    logger.info("No matching voice message found, suggesting download all as fallback");
     sendResponse({
       success: true,
-      message: "Right-click info recorded, but download URL not found",
+      action: MESSAGE_ACTIONS.DOWNLOAD_ALL_VOICE_MESSAGES,
+      message: "No matching voice message found, ready to download all available voice messages",
     });
     return true;
   }

--- a/extension/scripts/background/message-handler.ts
+++ b/extension/scripts/background/message-handler.ts
@@ -13,6 +13,7 @@ import {
   handleBlobUrl,
   handleBlobDetection,
 } from "./handlers/blob-handler";
+import { handleDownloadAll } from "./handlers/download-all-handler";
 import { createDataStore, type VoiceMessageStore } from "./data-store";
 
 // Create a module-specific logger
@@ -122,6 +123,22 @@ export function initMessageHandler(voiceMessages?: VoiceMessageStore): void {
         case MESSAGE_ACTIONS.BLOB_DETECTED:
           logger.debug("Handling Blob URL detected message");
           return handleBlobDetection(message, sender, sendResponse);
+
+        case MESSAGE_ACTIONS.DOWNLOAD_ALL_VOICE_MESSAGES:
+          logger.debug("Handling download all voice messages message");
+          if (!voiceMessagesStore) {
+            sendResponse({
+              success: false,
+              error: "Voice message store not initialized",
+            });
+            return false;
+          }
+          return handleDownloadAll(
+            voiceMessagesStore,
+            message,
+            sender,
+            sendResponse
+          );
 
         default:
           logger.warn("Unhandled message type", {

--- a/extension/scripts/content/context-menu-handler.ts
+++ b/extension/scripts/content/context-menu-handler.ts
@@ -68,10 +68,33 @@ function handleContextMenu(event: MouseEvent): void {
   });
 
   if (!result) {
-    // If no voice message element is found, do nothing
-    Logger.debug("No voice message element found", {
+    // If no voice message element is found, trigger batch download as fallback
+    Logger.debug("No voice message element found, triggering batch download as fallback", {
       module: MODULE_NAMES.CONTEXT_MENU,
     });
+    
+    // Send download all message directly
+    const downloadAllMessage = {
+      action: MESSAGE_ACTIONS.DOWNLOAD_ALL_VOICE_MESSAGES,
+    };
+    
+    try {
+      chrome.runtime.sendMessage(downloadAllMessage, (response) => {
+        Logger.debug("Download all message response", {
+          module: MODULE_NAMES.CONTEXT_MENU,
+          data: response,
+        });
+      });
+      Logger.info("Triggered batch download due to no voice message element found", {
+        module: MODULE_NAMES.CONTEXT_MENU,
+      });
+    } catch (error) {
+      Logger.error("Error sending download all message", {
+        module: MODULE_NAMES.CONTEXT_MENU,
+        data: error,
+      });
+    }
+    
     return;
   }
 

--- a/extension/scripts/content/context-menu-handler.ts
+++ b/extension/scripts/content/context-menu-handler.ts
@@ -68,33 +68,13 @@ function handleContextMenu(event: MouseEvent): void {
   });
 
   if (!result) {
-    // If no voice message element is found, trigger batch download as fallback
-    Logger.debug("No voice message element found, triggering batch download as fallback", {
+    // If no voice message element is found, still send right-click message for fallback
+    Logger.debug("No voice message element found, sending right-click message for fallback", {
       module: MODULE_NAMES.CONTEXT_MENU,
     });
     
-    // Send download all message directly
-    const downloadAllMessage = {
-      action: MESSAGE_ACTIONS.DOWNLOAD_ALL_VOICE_MESSAGES,
-    };
-    
-    try {
-      chrome.runtime.sendMessage(downloadAllMessage, (response) => {
-        Logger.debug("Download all message response", {
-          module: MODULE_NAMES.CONTEXT_MENU,
-          data: response,
-        });
-      });
-      Logger.info("Triggered batch download due to no voice message element found", {
-        module: MODULE_NAMES.CONTEXT_MENU,
-      });
-    } catch (error) {
-      Logger.error("Error sending download all message", {
-        module: MODULE_NAMES.CONTEXT_MENU,
-        data: error,
-      });
-    }
-    
+    // Send right-click message with null values - download all will be triggered when user clicks context menu
+    sendRightClickMessage(null, null, null, undefined);
     return;
   }
 

--- a/extension/scripts/types/messages.ts
+++ b/extension/scripts/types/messages.ts
@@ -109,6 +109,17 @@ export interface AudioDurationMessage extends BaseMessage {
   metadata?: RequestMetadata;
 }
 
+// ================================================
+// Download Related Messages
+// ================================================
+
+/**
+ * Download all voice messages request message interface
+ */
+export interface DownloadAllMessage extends BaseMessage {
+  // No additional parameters needed for download all request
+}
+
 // Chrome Extension event messages have been moved to chrome-extension.ts
 
 // ================================================

--- a/extension/scripts/utils/constants.ts
+++ b/extension/scripts/utils/constants.ts
@@ -97,6 +97,7 @@ export const MESSAGE_ACTIONS = {
   BLOB_DETECTED: "blobUrlDetected",
   UPDATE_ELEMENT: "updateVoiceMessageElement",
   GET_AUDIO_DURATION: "getAudioDuration",
+  DOWNLOAD_ALL_VOICE_MESSAGES: "downloadAllVoiceMessages",
 } as const;
 
 // ===========================================

--- a/extension/scripts/utils/time-utils.ts
+++ b/extension/scripts/utils/time-utils.ts
@@ -30,7 +30,7 @@ export function parseLastModifiedHeader(
 
 /**
  * Formats a date into a filename-friendly format
- * Format: YYYY-MM-DD-HH-mm-ss
+ * Format: YYYY-MM-DD-HH-mm-ss-SSS
  */
 export function formatDateForFilename(date: Date): string {
   if (!(date instanceof Date) || isNaN(date.getTime())) {
@@ -38,6 +38,7 @@ export function formatDateForFilename(date: Date): string {
   }
 
   const pad = (num: number): string => String(num).padStart(2, "0");
+  const padMs = (num: number): string => String(num).padStart(3, "0");
 
   const year = date.getFullYear();
   const month = pad(date.getMonth() + 1); // Month is 0-based
@@ -45,8 +46,9 @@ export function formatDateForFilename(date: Date): string {
   const hours = pad(date.getHours());
   const minutes = pad(date.getMinutes());
   const seconds = pad(date.getSeconds());
+  const milliseconds = padMs(date.getMilliseconds());
 
-  return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
+  return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}-${milliseconds}`;
 }
 
 /**

--- a/tests/unit/background/download-manager.test.ts
+++ b/tests/unit/background/download-manager.test.ts
@@ -1,15 +1,17 @@
 /// <reference types="jest" />
 
-import {
-  initDownloadManager,
-  setLastRightClickedInfo,
-  downloadVoiceMessage,
-  downloadAllVoiceMessages,
-} from "../../../extension/scripts/background/download-manager";
+import * as downloadManager from "../../../extension/scripts/background/download-manager";
 import type {
   RightClickInfo,
 } from "../../../extension/scripts/types/download";
 import type { VoiceMessageStore } from "../../../extension/scripts/background/data-store";
+
+const {
+  initDownloadManager,
+  setLastRightClickedInfo,
+  downloadVoiceMessage,
+  downloadAllVoiceMessages,
+} = downloadManager;
 
 // Mock dependencies
 jest.mock("../../../extension/scripts/utils/time-utils", () => ({
@@ -156,8 +158,23 @@ describe("download-manager.ts", () => {
       );
     });
 
-    it("should handle context menu click with null download URL", () => {
-      initDownloadManager();
+    it("should trigger batch download when download URL is null", () => {
+      const mockStore = createMockVoiceMessageStore();
+      mockStore.items.set("voice-msg-001", {
+        id: "voice-msg-001",
+        durationMs: 3000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: "Wed, 19 Mar 2025 14:04:40 GMT",
+        element: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(999);
+      });
+
+      initDownloadManager(mockStore);
       const addedListener =
         mockChrome.contextMenus.onClicked.addListener.mock.calls[0][0];
 
@@ -171,8 +188,14 @@ describe("download-manager.ts", () => {
 
       addedListener(mockInfo, undefined);
 
-      // downloadVoiceMessage should be called but should not call chrome.downloads.download due to empty URL
-      expect(mockChrome.downloads.download).not.toHaveBeenCalled();
+      // Should call chrome.downloads.download for batch download with saveAs: false
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+          saveAs: false,
+        }),
+        expect.any(Function)
+      );
     });
 
     it("should ignore non-download menu items", () => {

--- a/tests/unit/background/download-manager.test.ts
+++ b/tests/unit/background/download-manager.test.ts
@@ -372,6 +372,50 @@ describe("download-manager.ts", () => {
         expect.any(Function)
       );
     });
+
+    it("should download voice message with saveAs: false", () => {
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(777);
+      });
+
+      downloadVoiceMessage(
+        "https://example.com/audio.mp4",
+        "Wed, 19 Mar 2025 14:04:40 GMT",
+        "test-id",
+        false
+      );
+
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        {
+          url: "https://example.com/audio.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-test-id.mp4",
+          saveAs: false,
+        },
+        expect.any(Function)
+      );
+    });
+
+    it("should download voice message with saveAs: true explicitly", () => {
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(666);
+      });
+
+      downloadVoiceMessage(
+        "https://example.com/audio.mp4",
+        "Wed, 19 Mar 2025 14:04:40 GMT",
+        "test-id",
+        true
+      );
+
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        {
+          url: "https://example.com/audio.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-test-id.mp4",
+          saveAs: true,
+        },
+        expect.any(Function)
+      );
+    });
   });
 
   describe("downloadAllVoiceMessages", () => {
@@ -423,12 +467,14 @@ describe("download-manager.ts", () => {
       expect(mockChrome.downloads.download).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://example.com/audio1.mp4",
+          saveAs: false,
         }),
         expect.any(Function)
       );
       expect(mockChrome.downloads.download).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://example.com/audio2.mp4",
+          saveAs: false,
         }),
         expect.any(Function)
       );
@@ -472,6 +518,7 @@ describe("download-manager.ts", () => {
       expect(mockChrome.downloads.download).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://example.com/audio1.mp4",
+          saveAs: false,
         }),
         expect.any(Function)
       );
@@ -535,11 +582,12 @@ describe("download-manager.ts", () => {
       expect(result).toBe(2);
       expect(mockChrome.downloads.download).toHaveBeenCalledTimes(2);
       
-      // Verify that filenames include unique identifiers
+      // Verify that filenames include unique identifiers and saveAs is false for batch downloads
       expect(mockChrome.downloads.download).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://example.com/audio1.mp4",
           filename: "voice-message-2025-03-19-14-04-40-voice-msg-001.mp4",
+          saveAs: false,
         }),
         expect.any(Function)
       );
@@ -548,6 +596,7 @@ describe("download-manager.ts", () => {
         expect.objectContaining({
           url: "https://example.com/audio2.mp4",
           filename: "voice-message-2025-03-19-12-00-00-voice-msg-002.mp4",
+          saveAs: false,
         }),
         expect.any(Function)
       );

--- a/tests/unit/background/download-manager.test.ts
+++ b/tests/unit/background/download-manager.test.ts
@@ -188,11 +188,11 @@ describe("download-manager.ts", () => {
 
       addedListener(mockInfo, undefined);
 
-      // Should call chrome.downloads.download for batch download with saveAs: false
+      // Should call chrome.downloads.download for batch download with first file saveAs: true
       expect(mockChrome.downloads.download).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://example.com/audio1.mp4",
-          saveAs: false,
+          saveAs: true, // First file should show dialog when triggered from context menu
         }),
         expect.any(Function)
       );
@@ -620,6 +620,89 @@ describe("download-manager.ts", () => {
           url: "https://example.com/audio2.mp4",
           filename: "voice-message-2025-03-19-12-00-00-voice-msg-002.mp4",
           saveAs: false,
+        }),
+        expect.any(Function)
+      );
+    });
+
+    it("should download with first dialog when showFirstDialog is true", () => {
+      const mockStore = createMockVoiceMessageStore();
+      mockStore.items.set("voice-msg-001", {
+        id: "voice-msg-001",
+        durationMs: 3000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: "Wed, 19 Mar 2025 14:04:40 GMT",
+        element: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+      mockStore.items.set("voice-msg-002", {
+        id: "voice-msg-002",
+        durationMs: 5000,
+        downloadUrl: "https://example.com/audio2.mp4",
+        lastModified: null,
+        element: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(123);
+      });
+
+      const result = downloadAllVoiceMessages(mockStore, true);
+
+      expect(result).toBe(2);
+      expect(mockChrome.downloads.download).toHaveBeenCalledTimes(2);
+      
+      // First file should have saveAs: true
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-voice-msg-001.mp4",
+          saveAs: true,
+        }),
+        expect.any(Function)
+      );
+      
+      // Second file should have saveAs: false
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio2.mp4",
+          filename: "voice-message-2025-03-19-12-00-00-voice-msg-002.mp4",
+          saveAs: false,
+        }),
+        expect.any(Function)
+      );
+    });
+
+    it("should download single file with dialog when showFirstDialog is true", () => {
+      const mockStore = createMockVoiceMessageStore();
+      mockStore.items.set("voice-msg-001", {
+        id: "voice-msg-001",
+        durationMs: 3000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: "Wed, 19 Mar 2025 14:04:40 GMT",
+        element: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(123);
+      });
+
+      const result = downloadAllVoiceMessages(mockStore, true);
+
+      expect(result).toBe(1);
+      expect(mockChrome.downloads.download).toHaveBeenCalledTimes(1);
+      
+      // Single file should have saveAs: true when showFirstDialog is true
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-voice-msg-001.mp4",
+          saveAs: true,
         }),
         expect.any(Function)
       );

--- a/tests/unit/background/download-manager.test.ts
+++ b/tests/unit/background/download-manager.test.ts
@@ -4,10 +4,12 @@ import {
   initDownloadManager,
   setLastRightClickedInfo,
   downloadVoiceMessage,
+  downloadAllVoiceMessages,
 } from "../../../extension/scripts/background/download-manager";
 import type {
   RightClickInfo,
 } from "../../../extension/scripts/types/download";
+import type { VoiceMessageStore } from "../../../extension/scripts/background/data-store";
 
 // Mock dependencies
 jest.mock("../../../extension/scripts/utils/time-utils", () => ({
@@ -68,6 +70,18 @@ function createMockRightClickInfo(
     lastModified: lastModified || null,
     tabId: tabId,
     durationMs: durationMs,
+  };
+}
+
+// Helper function to create mock voice message store
+function createMockVoiceMessageStore(): VoiceMessageStore {
+  return {
+    items: new Map(),
+    isDurationMatch: jest.fn(),
+    registerDownloadUrl: jest.fn(),
+    findPendingItemByDuration: jest.fn(),
+    findItemByDuration: jest.fn(),
+    getDownloadUrlForElement: jest.fn(),
   };
 }
 
@@ -315,6 +329,131 @@ describe("download-manager.ts", () => {
       downloadVoiceMessage("https://example.com/audio.mp4");
 
       expect(mockChrome.downloads.download).toHaveBeenCalled();
+    });
+  });
+
+  describe("downloadAllVoiceMessages", () => {
+    it("should return 0 when datastore is empty", () => {
+      const mockStore = createMockVoiceMessageStore();
+      
+      const result = downloadAllVoiceMessages(mockStore);
+      
+      expect(result).toBe(0);
+      expect(mockChrome.downloads.download).not.toHaveBeenCalled();
+    });
+
+    it("should download all voice messages with valid URLs", () => {
+      const mockStore = createMockVoiceMessageStore();
+      
+      // Add test items to the store
+      mockStore.items.set("item1", {
+        id: "item1",
+        element: null,
+        durationMs: 5000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: "Wed, 19 Mar 2025 14:04:40 GMT",
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+      
+      mockStore.items.set("item2", {
+        id: "item2",
+        element: null,
+        durationMs: 3000,
+        downloadUrl: "https://example.com/audio2.mp4",
+        lastModified: null,
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(123);
+      });
+
+      const result = downloadAllVoiceMessages(mockStore);
+
+      expect(result).toBe(2);
+      expect(mockChrome.downloads.download).toHaveBeenCalledTimes(2);
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+        }),
+        expect.any(Function)
+      );
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio2.mp4",
+        }),
+        expect.any(Function)
+      );
+    });
+
+    it("should skip items without download URLs", () => {
+      const mockStore = createMockVoiceMessageStore();
+      
+      mockStore.items.set("item1", {
+        id: "item1",
+        element: null,
+        durationMs: 5000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: null,
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+      
+      mockStore.items.set("item2", {
+        id: "item2",
+        element: null,
+        durationMs: 3000,
+        downloadUrl: null,
+        lastModified: null,
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(123);
+      });
+
+      const result = downloadAllVoiceMessages(mockStore);
+
+      expect(result).toBe(1);
+      expect(mockChrome.downloads.download).toHaveBeenCalledTimes(1);
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+        }),
+        expect.any(Function)
+      );
+    });
+
+    it("should skip items with empty download URLs", () => {
+      const mockStore = createMockVoiceMessageStore();
+      
+      mockStore.items.set("item1", {
+        id: "item1",
+        element: null,
+        durationMs: 5000,
+        downloadUrl: "",
+        lastModified: null,
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      const result = downloadAllVoiceMessages(mockStore);
+
+      expect(result).toBe(0);
+      expect(mockChrome.downloads.download).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/background/download-manager.test.ts
+++ b/tests/unit/background/download-manager.test.ts
@@ -330,6 +330,48 @@ describe("download-manager.ts", () => {
 
       expect(mockChrome.downloads.download).toHaveBeenCalled();
     });
+
+    it("should download voice message with unique identifier", () => {
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(999);
+      });
+
+      downloadVoiceMessage(
+        "https://example.com/audio.mp4",
+        "Wed, 19 Mar 2025 14:04:40 GMT",
+        "unique-id-123"
+      );
+
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        {
+          url: "https://example.com/audio.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-unique-id-123.mp4",
+          saveAs: true,
+        },
+        expect.any(Function)
+      );
+    });
+
+    it("should download voice message with unique identifier but without lastModified", () => {
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(888);
+      });
+
+      downloadVoiceMessage(
+        "https://example.com/audio.mp4",
+        undefined,
+        "another-unique-id"
+      );
+
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        {
+          url: "https://example.com/audio.mp4",
+          filename: "voice-message-2025-03-19-12-00-00-another-unique-id.mp4",
+          saveAs: true,
+        },
+        expect.any(Function)
+      );
+    });
   });
 
   describe("downloadAllVoiceMessages", () => {
@@ -454,6 +496,61 @@ describe("download-manager.ts", () => {
 
       expect(result).toBe(0);
       expect(mockChrome.downloads.download).not.toHaveBeenCalled();
+    });
+
+    it("should include unique identifiers in filenames for batch download", () => {
+      const mockStore = createMockVoiceMessageStore();
+      
+      // Add test items with different IDs
+      mockStore.items.set("voice-msg-001", {
+        id: "voice-msg-001",
+        element: null,
+        durationMs: 5000,
+        downloadUrl: "https://example.com/audio1.mp4",
+        lastModified: "Wed, 19 Mar 2025 14:04:40 GMT",
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+      
+      mockStore.items.set("voice-msg-002", {
+        id: "voice-msg-002",
+        element: null,
+        durationMs: 3000,
+        downloadUrl: "https://example.com/audio2.mp4",
+        lastModified: null,
+        blobType: null,
+        blobSize: null,
+        timestamp: Date.now(),
+        isPending: false,
+      });
+
+      mockChrome.downloads.download.mockImplementation((options, callback) => {
+        callback(123);
+      });
+
+      const result = downloadAllVoiceMessages(mockStore);
+
+      expect(result).toBe(2);
+      expect(mockChrome.downloads.download).toHaveBeenCalledTimes(2);
+      
+      // Verify that filenames include unique identifiers
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio1.mp4",
+          filename: "voice-message-2025-03-19-14-04-40-voice-msg-001.mp4",
+        }),
+        expect.any(Function)
+      );
+      
+      expect(mockChrome.downloads.download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/audio2.mp4",
+          filename: "voice-message-2025-03-19-12-00-00-voice-msg-002.mp4",
+        }),
+        expect.any(Function)
+      );
     });
   });
 });

--- a/tests/unit/background/handlers/download-all-handler.test.ts
+++ b/tests/unit/background/handlers/download-all-handler.test.ts
@@ -1,0 +1,416 @@
+/**
+ * download-all-handler.test.ts
+ * Unit tests for download-all-handler module
+ */
+
+// Mock modules first
+const mockDownloadAllVoiceMessages = jest.fn();
+jest.mock("../../../../extension/scripts/background/download-manager", () => ({
+  downloadAllVoiceMessages: mockDownloadAllVoiceMessages,
+}));
+
+jest.mock("../../../../extension/scripts/utils/constants", () => ({
+  MODULE_NAMES: {
+    DOWNLOAD_ALL_HANDLER: "download-all-handler",
+  },
+}));
+
+jest.mock("../../../../extension/scripts/utils/logger", () => ({
+  Logger: {
+    createModuleLogger: jest.fn(() => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    })),
+  },
+}));
+
+describe("download-all-handler.ts", () => {
+  let mockLogger: any;
+  let downloadAllHandler: any;
+  let mockVoiceMessagesStore: any;
+  let mockSender: any;
+  let mockSendResponse: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+
+    // Create fresh mock logger for each test
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    // Create mock voice messages store
+    mockVoiceMessagesStore = {
+      items: new Map(),
+      findItemByDuration: jest.fn(),
+    };
+
+    // Create mock sender and response
+    mockSender = {
+      tab: { id: 123 },
+    };
+    mockSendResponse = jest.fn();
+
+    // Set up mocks
+    const { Logger } = require("../../../../extension/scripts/utils/logger");
+    Logger.createModuleLogger.mockReturnValue(mockLogger);
+
+    // Clear download manager mock
+    mockDownloadAllVoiceMessages.mockClear();
+
+    // Import after mocks are set up
+    downloadAllHandler = require("../../../../extension/scripts/background/handlers/download-all-handler");
+  });
+
+  describe("handleDownloadAll", () => {
+    describe("Normal Cases", () => {
+      it("should handle download all request with items available", () => {
+        // Mock store with items
+        mockVoiceMessagesStore.items.set("item1", {
+          id: "item1",
+          durationMs: 5000,
+          downloadUrl: "https://example.com/audio1.mp3",
+          lastModified: null,
+        });
+
+        mockVoiceMessagesStore.items.set("item2", {
+          id: "item2",
+          durationMs: 3000,
+          downloadUrl: "https://example.com/audio2.mp3",
+          lastModified: null,
+        });
+
+        mockDownloadAllVoiceMessages.mockReturnValue(2);
+
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "Started downloading all available voice messages (2 files)",
+          downloadCount: 2,
+        });
+      });
+
+      it("should handle download all request with no items available", () => {
+        // Empty store
+        mockDownloadAllVoiceMessages.mockReturnValue(0);
+
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "No downloadable voice messages available in cache",
+          downloadCount: 0,
+        });
+      });
+
+      it("should handle download all request with single item", () => {
+        mockVoiceMessagesStore.items.set("item1", {
+          id: "item1",
+          durationMs: 5000,
+          downloadUrl: "https://example.com/audio1.mp3",
+          lastModified: null,
+        });
+
+        mockDownloadAllVoiceMessages.mockReturnValue(1);
+
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "Started downloading all available voice messages (1 files)",
+          downloadCount: 1,
+        });
+      });
+
+      it("should handle download all request with large number of items", () => {
+        // Mock a large number of items
+        for (let i = 0; i < 50; i++) {
+          mockVoiceMessagesStore.items.set(`item${i}`, {
+            id: `item${i}`,
+            durationMs: 1000 + i * 100,
+            downloadUrl: `https://example.com/audio${i}.mp3`,
+            lastModified: null,
+          });
+        }
+
+        mockDownloadAllVoiceMessages.mockReturnValue(50);
+
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "Started downloading all available voice messages (50 files)",
+          downloadCount: 50,
+        });
+      });
+    });
+
+    describe("Error Handling", () => {
+      it("should handle null voiceMessagesStore", () => {
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          null,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          "voiceMessagesStore does not exist"
+        );
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: false,
+          message: "Internal error: voiceMessagesStore does not exist",
+        });
+        expect(mockDownloadAllVoiceMessages).not.toHaveBeenCalled();
+      });
+
+      it("should handle undefined voiceMessagesStore", () => {
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          undefined,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          "voiceMessagesStore does not exist"
+        );
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: false,
+          message: "Internal error: voiceMessagesStore does not exist",
+        });
+        expect(mockDownloadAllVoiceMessages).not.toHaveBeenCalled();
+      });
+
+      it("should handle voiceMessagesStore without items property", () => {
+        const invalidStore = {};
+
+        mockDownloadAllVoiceMessages.mockReturnValue(0);
+
+        const message = {};
+
+        const result = downloadAllHandler.handleDownloadAll(
+          invalidStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(invalidStore);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "No downloadable voice messages available in cache",
+          downloadCount: 0,
+        });
+      });
+    });
+
+    describe("Integration with downloadAllVoiceMessages", () => {
+      it("should pass correct store to downloadAllVoiceMessages", () => {
+        const message = {};
+
+        mockDownloadAllVoiceMessages.mockReturnValue(3);
+
+        const result = downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledTimes(1);
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+      });
+
+      it("should handle when downloadAllVoiceMessages throws error", () => {
+        const message = {};
+
+        mockDownloadAllVoiceMessages.mockImplementation(() => {
+          throw new Error("Download failed");
+        });
+
+        expect(() => {
+          downloadAllHandler.handleDownloadAll(
+            mockVoiceMessagesStore,
+            message,
+            mockSender,
+            mockSendResponse
+          );
+        }).toThrow("Download failed");
+
+        expect(mockDownloadAllVoiceMessages).toHaveBeenCalledWith(mockVoiceMessagesStore);
+      });
+    });
+
+    describe("Logging Behavior", () => {
+      it("should log debug information", () => {
+        mockDownloadAllVoiceMessages.mockReturnValue(1);
+
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          "Handling download all voice messages request"
+        );
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          "voiceMessagesStore Map size",
+          { mapSize: 0 }
+        );
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          "Download all voice messages handling complete"
+        );
+      });
+
+      it("should log info for successful downloads", () => {
+        mockDownloadAllVoiceMessages.mockReturnValue(5);
+
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          "Executing batch download of all available voice messages"
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          "Batch download initiated",
+          { downloadCount: 5 }
+        );
+      });
+
+      it("should log warning when no downloads available", () => {
+        mockDownloadAllVoiceMessages.mockReturnValue(0);
+
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          "No downloadable voice messages found in cache"
+        );
+      });
+    });
+
+    describe("Response Format", () => {
+      it("should return response with correct format for successful downloads", () => {
+        mockDownloadAllVoiceMessages.mockReturnValue(3);
+
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "Started downloading all available voice messages (3 files)",
+          downloadCount: 3,
+        });
+      });
+
+      it("should return response with correct format for no downloads", () => {
+        mockDownloadAllVoiceMessages.mockReturnValue(0);
+
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          message: "No downloadable voice messages available in cache",
+          downloadCount: 0,
+        });
+      });
+
+      it("should return error response for invalid store", () => {
+        const message = {};
+
+        downloadAllHandler.handleDownloadAll(
+          null,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: false,
+          message: "Internal error: voiceMessagesStore does not exist",
+        });
+      });
+    });
+  });
+});

--- a/tests/unit/background/handlers/right-click-handler.test.ts
+++ b/tests/unit/background/handlers/right-click-handler.test.ts
@@ -13,6 +13,9 @@ jest.mock("../../../../extension/scripts/utils/constants", () => ({
   MODULE_NAMES: {
     RIGHT_CLICK_HANDLER: "right-click-handler",
   },
+  MESSAGE_ACTIONS: {
+    DOWNLOAD_ALL_VOICE_MESSAGES: "downloadAllVoiceMessages",
+  },
 }));
 
 jest.mock("../../../../extension/scripts/utils/logger", () => ({
@@ -203,7 +206,7 @@ describe("right-click-handler.ts", () => {
         });
       });
 
-      it("should record right-click info even without valid download URL", () => {
+      it("should record right-click info and suggest download all when no valid download URL", () => {
         const message = {
           elementId: "element-123",
           downloadUrl: null,
@@ -231,7 +234,8 @@ describe("right-click-handler.ts", () => {
         });
         expect(mockSendResponse).toHaveBeenCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
       });
     });
@@ -309,7 +313,8 @@ describe("right-click-handler.ts", () => {
         });
         expect(mockSendResponse).toHaveBeenCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
       });
 
@@ -342,7 +347,8 @@ describe("right-click-handler.ts", () => {
         expect(result).toBe(true);
         expect(mockSendResponse).toHaveBeenCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
       });
 
@@ -375,7 +381,8 @@ describe("right-click-handler.ts", () => {
         expect(result).toBe(true);
         expect(mockSendResponse).toHaveBeenCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
       });
 
@@ -553,7 +560,8 @@ describe("right-click-handler.ts", () => {
         });
         expect(mockSendResponse).toHaveBeenCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
       });
 
@@ -605,7 +613,8 @@ describe("right-click-handler.ts", () => {
         expect(result).toBe(true);
         expect(mockSendResponse).toHaveBeenLastCalledWith({
           success: true,
-          message: "Right-click info recorded, but download URL not found",
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
         });
 
         // Step 2: Add matching item to store
@@ -687,6 +696,71 @@ describe("right-click-handler.ts", () => {
         expect(
           mockVoiceMessagesStore.findItemByDuration
         ).not.toHaveBeenCalled();
+      });
+
+      it("should suggest download all when no download URL found", () => {
+        // Mock store with some items but no matching duration
+        mockVoiceMessagesStore.items.set("item1", {
+          id: "item1",
+          durationMs: 3000,
+          downloadUrl: "https://example.com/audio1.mp3",
+          lastModified: null,
+        });
+        
+        mockVoiceMessagesStore.items.set("item2", {
+          id: "item2",
+          durationMs: 7000,
+          downloadUrl: "https://example.com/audio2.mp3",
+          lastModified: null,
+        });
+
+        mockVoiceMessagesStore.findItemByDuration.mockReturnValue(null);
+
+        const message = {
+          elementId: "element-123",
+          downloadUrl: null,
+          lastModified: null,
+          durationMs: 5000,
+        };
+
+        const result = rightClickHandler.handleRightClick(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
+        });
+      });
+
+      it("should suggest download all even when no items in store", () => {
+        mockVoiceMessagesStore.findItemByDuration.mockReturnValue(null);
+
+        const message = {
+          elementId: "element-123",
+          downloadUrl: null,
+          lastModified: null,
+          durationMs: 5000,
+        };
+
+        const result = rightClickHandler.handleRightClick(
+          mockVoiceMessagesStore,
+          message,
+          mockSender,
+          mockSendResponse
+        );
+
+        expect(result).toBe(true);
+        expect(mockSendResponse).toHaveBeenCalledWith({
+          success: true,
+          action: "downloadAllVoiceMessages",
+          message: "No matching voice message found, ready to download all available voice messages",
+        });
       });
     });
   });

--- a/tests/unit/background/message-handler.test.ts
+++ b/tests/unit/background/message-handler.test.ts
@@ -20,6 +20,7 @@ jest.mock("../../../extension/scripts/utils/constants", () => ({
     REGISTER_AUDIO_URL: "REGISTER_AUDIO_URL",
     REGISTER_BLOB_URL: "REGISTER_BLOB_URL",
     BLOB_DETECTED: "BLOB_DETECTED",
+    DOWNLOAD_ALL_VOICE_MESSAGES: "DOWNLOAD_ALL_VOICE_MESSAGES",
   },
   MODULE_NAMES: {
     MESSAGE_HANDLER: "message-handler",
@@ -64,6 +65,13 @@ jest.mock(
     handleBlobUrl: jest.fn(),
     handleBlobContent: jest.fn(),
     handleBlobDetection: jest.fn(),
+  })
+);
+
+jest.mock(
+  "../../../extension/scripts/background/handlers/download-all-handler",
+  () => ({
+    handleDownloadAll: jest.fn(),
   })
 );
 
@@ -117,6 +125,7 @@ describe("MessageHandler", () => {
       handleBlobUrl: jest.fn(),
       handleBlobContent: jest.fn(),
       handleBlobDetection: jest.fn(),
+      handleDownloadAll: jest.fn(),
     };
 
     // Set up mocks
@@ -150,6 +159,11 @@ describe("MessageHandler", () => {
     );
     blobHandler.handleBlobDetection.mockImplementation(
       mockHandlers.handleBlobDetection
+    );
+
+    const downloadAllHandler = require("../../../extension/scripts/background/handlers/download-all-handler");
+    downloadAllHandler.handleDownloadAll.mockImplementation(
+      mockHandlers.handleDownloadAll
     );
 
     // Import after mocks are set up

--- a/tests/unit/utils/time-utils.test.ts
+++ b/tests/unit/utils/time-utils.test.ts
@@ -73,19 +73,19 @@ describe("formatDateForFilename", () => {
     it("should correctly format date for filename", () => {
       const date = new Date("2025-03-19T14:04:40.000");
       const result = formatDateForFilename(date);
-      expect(result).toBe("2025-03-19-14-04-40");
+      expect(result).toBe("2025-03-19-14-04-40-000");
     });
 
     it("should correctly handle zero padding", () => {
       const date = new Date("2025-01-01T01:01:01.000");
       const result = formatDateForFilename(date);
-      expect(result).toBe("2025-01-01-01-01-01");
+      expect(result).toBe("2025-01-01-01-01-01-000");
     });
 
     it("should handle end of year date", () => {
       const date = new Date("2025-12-31T23:59:59.000");
       const result = formatDateForFilename(date);
-      expect(result).toBe("2025-12-31-23-59-59");
+      expect(result).toBe("2025-12-31-23-59-59-000");
     });
   });
 
@@ -94,22 +94,22 @@ describe("formatDateForFilename", () => {
       const invalidDate = new Date("invalid");
       const result = formatDateForFilename(invalidDate);
       // Should return current time format (we can't predict exact time, so check format)
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/);
     });
 
     it("should handle null input", () => {
       const result = formatDateForFilename(null as any);
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/);
     });
 
     it("should handle undefined input", () => {
       const result = formatDateForFilename(undefined as any);
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/);
     });
 
     it("should handle non-date object input", () => {
       const result = formatDateForFilename("not-a-date" as any);
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/);
     });
   });
 });
@@ -120,20 +120,20 @@ describe("generateVoiceMessageFilename", () => {
       const result = generateVoiceMessageFilename(
         "Wed, 19 Mar 2025 14:04:40 GMT"
       );
-      expect(result).toMatch(/^voice-message-2025-03-19-\d{2}-04-40$/);
+      expect(result).toMatch(/^voice-message-2025-03-19-\d{2}-04-40-\d{3}$/);
     });
 
     it("should use current time when lastModified is not provided", () => {
       const result = generateVoiceMessageFilename();
       expect(result).toMatch(
-        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/
+        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/
       );
     });
 
     it("should use current time when lastModified is an empty string", () => {
       const result = generateVoiceMessageFilename("");
       expect(result).toMatch(
-        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/
+        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/
       );
     });
   });
@@ -142,14 +142,14 @@ describe("generateVoiceMessageFilename", () => {
     it("should handle invalid lastModified format", () => {
       const result = generateVoiceMessageFilename("invalid-date");
       expect(result).toMatch(
-        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/
+        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/
       );
     });
 
     it("should handle null lastModified", () => {
       const result = generateVoiceMessageFilename(null as any);
       expect(result).toMatch(
-        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/
+        /^voice-message-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{3}$/
       );
     });
   });


### PR DESCRIPTION
- Updated logging to reflect the use of first dialog for batch downloads
- Modified downloadAllVoiceMessages to accept showFirstDialog parameter
- Implemented logic to show save dialog for the first file during batch downloads
- Added tests to verify first dialog behavior for batch and single file downloads