### PR TITLE
fix: 修正每日 Canary 失敗回報

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -45,11 +45,16 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Materialise storageState
+        id: storage_state
+        continue-on-error: true
         env:
           FB_CANARY_STORAGE_STATE: ${{ secrets.FB_CANARY_STORAGE_STATE }}
         run: |
+          OUT="$RUNNER_TEMP/canary-output.txt"
+          : > "$OUT"
           if [ -z "$FB_CANARY_STORAGE_STATE" ]; then
             echo "::error::FB_CANARY_STORAGE_STATE secret is unset. The canary cannot sign in."
+            echo "VERDICT: storage-state-misconfigured — FB_CANARY_STORAGE_STATE is unset" >> "$OUT"
             exit 1
           fi
           # Written outside the workspace so no step can archive it into an
@@ -58,16 +63,21 @@ jobs:
           # Validate shape before spending five minutes finding out it is garbage.
           if ! jq -e '.cookies' "$RUNNER_TEMP/storage-state.json" > /dev/null 2>&1; then
             echo "::error::FB_CANARY_STORAGE_STATE is not a valid Playwright storageState JSON (no .cookies array)."
+            echo "VERDICT: storage-state-misconfigured — FB_CANARY_STORAGE_STATE is invalid" >> "$OUT"
             exit 1
           fi
           echo "storageState materialised ($(jq '.cookies | length' "$RUNNER_TEMP/storage-state.json") cookies)"
 
       - name: Run canary
         id: canary
+        if: steps.storage_state.outcome == 'success'
         continue-on-error: true
+        shell: bash
         env:
           FB_CANARY_STORAGE_STATE_PATH: ${{ runner.temp }}/storage-state.json
-          FB_CANARY_THREAD_URL: ${{ vars.FB_CANARY_THREAD_URL }}
+          # The repository is public. Keep the private thread identifier masked
+          # in logs by storing its full URL as a secret rather than a variable.
+          FB_CANARY_THREAD_URL: ${{ secrets.FB_CANARY_THREAD_URL }}
         run: pnpm test:canary 2>&1 | tee "$RUNNER_TEMP/canary-output.txt"
 
       - name: Redact storageState
@@ -87,13 +97,18 @@ jobs:
 
       - name: Classify failure
         id: classify
-        if: steps.canary.outcome == 'failure'
+        if: always() && (steps.storage_state.outcome == 'failure' || steps.canary.outcome == 'failure')
+        env:
+          STORAGE_STATE_OUTCOME: ${{ steps.storage_state.outcome }}
         run: |
           OUT="$RUNNER_TEMP/canary-output.txt"
           # The spec prefixes each assertion message with a VERDICT line. Read the
           # most severe one present: an expired session explains every downstream
           # failure, so it wins over any drift verdict in the same run.
-          if grep -q "VERDICT: misconfigured" "$OUT"; then
+          if [ "$STORAGE_STATE_OUTCOME" = "failure" ]; then
+            echo "verdict=storage-state-misconfigured" >> "$GITHUB_OUTPUT"
+            echo "title=Canary: Facebook login state is missing or invalid" >> "$GITHUB_OUTPUT"
+          elif grep -q "VERDICT: misconfigured" "$OUT"; then
             echo "verdict=misconfigured" >> "$GITHUB_OUTPUT"
             echo "title=Canary: misconfigured — it is watching nothing" >> "$GITHUB_OUTPUT"
           elif grep -q "VERDICT: session-expired" "$OUT"; then
@@ -111,7 +126,7 @@ jobs:
           fi
 
       - name: Open or update canary issue
-        if: steps.canary.outcome == 'failure'
+        if: always() && (steps.storage_state.outcome == 'failure' || steps.canary.outcome == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERDICT: ${{ steps.classify.outputs.verdict }}
@@ -134,14 +149,24 @@ jobs:
             echo "**Verdict:** \`$VERDICT\`"
             echo
             case "$VERDICT" in
+              storage-state-misconfigured)
+                echo "The canary could not materialise its Facebook login state."
+                echo "The \`FB_CANARY_STORAGE_STATE\` repository secret is missing or is not valid"
+                echo "Playwright storageState JSON."
+                echo
+                echo "**Fix:** capture a fresh signed-in messenger.com storageState and update the"
+                echo "\`FB_CANARY_STORAGE_STATE\` repository secret."
+                echo
+                echo "Detection itself was not run because the canary could not sign in."
+                ;;
               misconfigured)
                 echo "The canary ran but had nothing to watch — the \`FB_CANARY_THREAD_URL\` repository"
-                echo "variable is unset. **Detection is not being monitored at all.**"
+                echo "secret is unset. **Detection is not being monitored at all.**"
                 echo
                 echo "**Fix:** point it at a messenger.com thread that contains at least one voice message:"
                 echo
                 echo '```'
-                echo "gh variable set FB_CANARY_THREAD_URL --body 'https://www.messenger.com/t/<thread-id>'"
+                echo "gh secret set FB_CANARY_THREAD_URL --body 'https://www.messenger.com/t/<thread-id>'"
                 echo '```'
                 ;;
               session-expired)
@@ -199,7 +224,7 @@ jobs:
           fi
 
       - name: Close the canary issue on recovery
-        if: steps.canary.outcome == 'success'
+        if: steps.storage_state.outcome == 'success' && steps.canary.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -213,7 +238,7 @@ jobs:
           # A green run is otherwise silent, by design.
 
       - name: Fail the job when the canary failed
-        if: steps.canary.outcome == 'failure'
+        if: always() && (steps.storage_state.outcome == 'failure' || steps.canary.outcome == 'failure')
         run: |
           echo "::error::Canary failed — see the canary-labelled issue."
           exit 1

--- a/docs/1.1.3-reliability-plan.md
+++ b/docs/1.1.3-reliability-plan.md
@@ -1,0 +1,100 @@
+# VoiLoad 1.1.3 reliability plan
+
+## 背景
+
+1.1.2 已發布。這份文件記錄 code review 確認、但不適合混入 `main` 同步工作的三個 runtime 問題。修正應在獨立 PR 完成，版本以 1.1.3 發布。
+
+## Scope
+
+### 1. 依頁籤隔離 voice-message store
+
+**現況**
+
+- `chrome.storage.session` 內的 voice-message store 為整個 extension 共用。
+- URL registration 沒有保存 `sender.tab.id` 或 `sender.documentId`。
+- duration lookup 與 download-all 會搜尋所有已保存項目。
+
+**風險**
+
+同時開啟多個 Messenger／Facebook 頁籤時，目前頁籤可能命中另一頁籤內時長相近的語音；download-all 也可能下載其他頁籤或先前頁面的項目。這是錯檔與隱私風險。
+
+**建議設計**
+
+- `VoiceMessageItem` 增加來源 scope：至少 `tabId`，可取得時一併保存 `documentId`。
+- blob/audio registration 從 `MessageSender` 寫入 scope。
+- `findItemByDuration` 與 `getAllItems` 必須接收 scope，只回傳目前頁面資料。
+- hydrate 舊資料時，對沒有 scope 的 1.1.2 item 採安全降級：不得參與跨頁籤 lookup；必要時清除。
+
+**驗收條件**
+
+- 兩個頁籤各有相同時長語音，右鍵下載只取得目前頁籤的音檔。
+- download-all 只處理觸發頁籤的項目。
+- service worker 重啟並 hydrate 後仍維持隔離。
+- 來源頁籤已關閉時，不向其他頁籤請求 WAV；改用該 item 的原始 URL 或略過。
+
+### 2. 讓 WAV URL 具備 request-scoped lifecycle
+
+**現況**
+
+- page context 以單一 `currentWavUrl` 保存轉換結果。
+- 下一次轉換完成時會 revoke 前一個 URL。
+- 多個 `PREPARE_WAV` 可以並行；content timeout 不會取消仍在 page context 執行的轉換。
+
+**風險**
+
+較慢的舊請求或另一個並行請求，可能在 `chrome.downloads.download` 接手前 revoke 正在使用的 URL，造成間歇性下載失敗。
+
+**建議設計**
+
+- 以 `requestId` 保存 `Map<requestId, wavUrl>`，不再共用單一槽位。
+- background 建立 `requestId`，隨 `REQUEST_WAV` 傳給 content；content 再隨 `PREPARE_WAV` 傳給 page context。
+- page context 的結果與 content 回給 background 的 response 都必須包含同一組 `{ requestId, wavUrl }`。
+- 新增 `MESSAGE_ACTIONS.RELEASE_WAV` 與對應訊息型別；background 透過 content 將 release 訊息轉送至 page context。
+- background 在 `chrome.downloads.download` callback 後送出 `RELEASE_WAV(requestId)`。
+- page context 只 revoke 指定 request 的 URL。
+- 加入 TTL，回收未收到 release acknowledgement 的 URL。
+
+**驗收條件**
+
+- 兩個轉換並行且完成順序反轉，兩個 URL 都能成功下載。
+- content request timeout 後完成的舊轉換，不會 revoke 新請求的 URL。
+- release acknowledgement 只撤銷對應 URL。
+- 遺失 acknowledgement 時，TTL 能回收 URL。
+
+### 3. 讓 retention 不依賴 MV3 長時間 timer
+
+**現況**
+
+- 七天資料淘汰只由 background service worker 內的 24 小時 `setInterval` 觸發。
+- MV3 service worker 閒置後會被終止，timer 會一併消失並在下次喚醒重算。
+
+**風險**
+
+正常使用下 cleanup 幾乎不會執行；舊資料持續累積，使 duration matching 更容易模糊，也擴大 download-all 的錯誤範圍。
+
+**建議設計**
+
+- 首選：`hydrate()` 時依 `DATA_RETENTION_PERIOD` 過濾並立即回寫，不新增 permission。
+- 同時修正 `sourceBlobs` 更新既有 duration 時的 Map 順序：先 `delete` 再 `set`，確保最近更新的項目不會被當成最舊資料淘汰。
+- 不採用 service-worker `setInterval`；除非未來確實需要準時背景清理，才改用 `chrome.alarms`。
+
+**驗收條件**
+
+- 模擬 service worker 重啟，hydrate 會刪除超過七天的項目並持久化結果。
+- 未過期項目保持不變。
+- 更新已存在的 source blob 後，它會移到 retention order 尾端。
+- 超過 `MAX_RETAINED` 時淘汰真正最舊、而非剛更新的 blob。
+
+## Out of scope
+
+- Canary workflow 與 GitHub repository variable 設定。
+- base64 舊管線、重複測試、過時架構文件等 cleanup。
+- 新功能或 UI 行為變更。
+
+## Release gate
+
+- `pnpm check`
+- `pnpm build`
+- Playwright E2E 29/29
+- 新增上述 multi-tab、concurrent WAV、service-worker restart regression tests
+- `extension/manifest.json` 與 `package.json` 同步升至 1.1.3

--- a/tests/canary/messenger-drift.spec.ts
+++ b/tests/canary/messenger-drift.spec.ts
@@ -88,9 +88,9 @@ test.describe("messenger.com drift canary", () => {
           "FB_CANARY_THREAD_URL is not set, so the canary has no thread to open",
           "and is watching nothing.",
           "",
-          "Fix: set the FB_CANARY_THREAD_URL repository variable to a messenger.com",
+          "Fix: set the FB_CANARY_THREAD_URL repository secret to a messenger.com",
           "thread URL containing at least one voice message, e.g.",
-          "  gh variable set FB_CANARY_THREAD_URL --body 'https://www.messenger.com/t/<thread-id>'",
+          "  gh secret set FB_CANARY_THREAD_URL --body 'https://www.messenger.com/t/<thread-id>'",
         ].join("\n")
       );
     }


### PR DESCRIPTION
## 摘要

- 讓 storage state 設定錯誤也會進入 Canary 分類與 GitHub Issue 回報流程
- 啟用 bash pipefail，避免 Playwright 失敗被 tee 的成功狀態掩蓋；Messenger thread URL 改由 repository secret 提供
- 新增 1.1.3 reliability plan，記錄跨分頁 session、WAV URL 生命週期與 MV3 清理排程三項後續工作

## Test plan

- pnpm check（27 suites／615 tests、TypeScript、ESLint）
- pnpm build
- Ruby YAML parse
- pnpm exec playwright test tests/canary/messenger-drift.spec.ts --list（3 tests）
- GitHub Actions：Test, Quality & Build、E2E (Playwright) 均通過